### PR TITLE
disable testing repo

### DIFF
--- a/qubes-dist-upgrade.sh
+++ b/qubes-dist-upgrade.sh
@@ -401,7 +401,7 @@ fi
 eval set -- "$OPTS"
 
 # Common DNF options
-dnf_opts_noclean='--best --allowerasing --enablerepo=*testing*'
+dnf_opts_noclean='--best --allowerasing'
 
 while [[ $# -gt 0 ]]; do
     case "$1" in


### PR DESCRIPTION
Prevents a 404 for https://yum.qubes-os.org/r4.0/templates-itl-testing/, fixing QubesOS/qubes-issues#7838.

**WARNING:** I do not understand this script and this patch was merely an educated guess.  While I tested it and it worked for me, it could cause unanticipated side effects. The merger accepts responsibility for the correctness of this fix.