### PR TITLE
missing alias `-l` for `--template-standalone-upgrade`

### DIFF
--- a/scripts/qubes-dist-upgrade-r4.3.sh
+++ b/scripts/qubes-dist-upgrade-r4.3.sh
@@ -157,7 +157,7 @@ if [[ $EUID -ne 0 ]]; then
     exit 1
 fi
 
-if ! OPTS=$(getopt -o trsxyu:n:f:jke --long releasever:,help,update,release-upgrade,dist-upgrade,template-standalone-upgrade,finalize,check-supported-templates,all-pre-reboot,all-post-reboot,assumeyes,usbvm:,netvm:,updatevm:,skip-template-upgrade,skip-standalone-upgrade,only-update:,max-concurrency:,keep-running:,enable-current-testing -n "$0" -- "$@"); then
+if ! OPTS=$(getopt -o tlrsxyu:n:f:jke --long releasever:,help,update,release-upgrade,dist-upgrade,template-standalone-upgrade,finalize,check-supported-templates,all-pre-reboot,all-post-reboot,assumeyes,usbvm:,netvm:,updatevm:,skip-template-upgrade,skip-standalone-upgrade,only-update:,max-concurrency:,keep-running:,enable-current-testing -n "$0" -- "$@"); then
     echo "ERROR: Failed while parsing options."
     exit 1
 fi


### PR DESCRIPTION
The flag `-l` is not recognized when parsing options:
```
[user@dom0 ~]$ sudo qubes-dist-upgrade --releasever=4.3 --enable-current-testing -l
/usr/lib/qubes/qubes-dist-upgrade-r4.3.sh: invalid option -- 'l'
ERROR: Failed while parsing options.
```

From the docs, the `-l` flag should be aliased to `--template-standalone-upgrade`:
```
--template-standalone-upgrade, -l (STAGE 4) Upgrade templates and standalone VMs to R4.3 repository.
```