### PR TITLE
Make preset-all failure non-fatal

### DIFF
--- a/scripts/qubes-dist-upgrade-r4.3.sh
+++ b/scripts/qubes-dist-upgrade-r4.3.sh
@@ -147,7 +147,9 @@ restore_rpmsave_policy() {
 }
 
 has_updated_qubes_version() {
-    grep -q 'VERSION_ID=4.3' /etc/os-release
+    grep -q 'VERSION_ID=4.3' /etc/os-release || return 1
+    xl info xen_version | grep -qF 4.19 || return 1
+    rpm -q qubes-core-qrexec-dom0 | grep -qF 4.3 || return 1
 }
 
 #-----------------------------------------------------------------------------#

--- a/scripts/qubes-dist-upgrade-r4.3.sh
+++ b/scripts/qubes-dist-upgrade-r4.3.sh
@@ -83,7 +83,7 @@ shutdown_nonessential_vms() {
         return
     fi
     mapfile -t running_vms < <(qvm-ls --running --raw-list --fields name)
-    keep_running=( dom0 "$usbvm" "$netvm" "$updatevm" "${extra_keep_running[@]}" )
+    keep_running=( dom0 "$usbvm" "${updatevm_deps[@]}" "${extra_keep_running[@]}" )
     # all the updates-proxy targets
     if [ -e "/etc/qubes-rpc/policy/qubes.UpdatesProxy" ]; then
         mapfile -t updates_proxy < <(grep '^\s*[^#].*target=' /etc/qubes-rpc/policy/qubes.UpdatesProxy | cut -d = -f 2)
@@ -228,6 +228,7 @@ if [ -z "${updatevm-}" ]; then
     # checks for that independently)
     updatevm=$(qubes-prefs updatevm 2>/dev/null || :)
 fi
+updatevm_deps=( "$netvm" "$updatevm" )
 max_concurrency="${max_concurrency:-4}"
 
 # Run prechecks first
@@ -245,6 +246,17 @@ if which xinput > /dev/null; then
     done
 else
     echo "WARNING: Unable to detect qubes providing input devices. PLease provide them using --keep-running option."
+fi
+
+# Add parent(s) of updatevm - for example sys-firewall for sys-whonix
+if [ -n "$updatevm" ]; then
+    parent=$(qvm-prefs "$updatevm" netvm || :)
+    while [ -n "$parent" ]; do
+        if [ "$parent" != "$netvm" ] && [[ ! " ${extra_keep_running[*]} " = *" $parent "* ]]; then
+            updatevm_deps+=( "$parent" )
+        fi
+        parent=$(qvm-prefs "$parent" netvm || :)
+    done
 fi
 
 # shellcheck disable=SC1003

--- a/scripts/qubes-dist-upgrade-r4.3.sh
+++ b/scripts/qubes-dist-upgrade-r4.3.sh
@@ -378,7 +378,7 @@ if [ "$assumeyes" == "1" ] || confirm "-> Launch upgrade process?"; then
                 fi
 
                 autostart_before=$(systemctl list-units --plain --quiet --all --full 'qubes-vm@*.service' | cut -f 1 -d ' ')
-                systemctl preset-all
+                systemctl preset-all || :
                 if [ -n "$autostart_before" ]; then
                     systemctl enable $autostart_before
                 fi

--- a/scripts/qubes-dist-upgrade-r4.3.sh
+++ b/scripts/qubes-dist-upgrade-r4.3.sh
@@ -433,6 +433,10 @@ if [ "$assumeyes" == "1" ] || confirm "-> Launch upgrade process?"; then
         if [ "${#all_vms[*]}" -gt 0 ]; then
             for vm in ${all_vms[*]};
             do
+                if ! qvm-features "$vm" qrexec >/dev/null; then
+                    echo "----> Skipping update of $vm, no qrexec detected"
+                    continue
+                fi
                 echo "----> Upgrading $vm..."
                 if [ "$(qvm-volume info "$vm:root" revisions_to_keep)" == 0 ]; then
                     echo "WARNING: No snapshot backup history is setup (revisions_to_keep = 0). We cannot revert upgrade in case of any issue."

--- a/scripts/qubes-dist-upgrade-r4.3.sh
+++ b/scripts/qubes-dist-upgrade-r4.3.sh
@@ -437,6 +437,10 @@ if [ "$assumeyes" == "1" ] || confirm "-> Launch upgrade process?"; then
                     echo "----> Skipping update of $vm, no qrexec detected"
                     continue
                 fi
+                if [ "$(qvm-features "$vm" qubes-agent-version || :)" = 4.3 ]; then
+                    echo "----> Skipping update of $vm, already updated to 4.3"
+                    continue
+                fi
                 echo "----> Upgrading $vm..."
                 if [ "$(qvm-volume info "$vm:root" revisions_to_keep)" == 0 ]; then
                     echo "WARNING: No snapshot backup history is setup (revisions_to_keep = 0). We cannot revert upgrade in case of any issue."

--- a/scripts/qubes-dist-upgrade-r4.3.sh
+++ b/scripts/qubes-dist-upgrade-r4.3.sh
@@ -447,7 +447,7 @@ if [ "$assumeyes" == "1" ] || confirm "-> Launch upgrade process?"; then
                 if [ "$enable_current_testing" ]; then
                     opt=--enable-current-testing
                 fi
-                qvm-run -q -u root -p "$vm" "bash /home/user/QubesIncoming/dom0/qubes-dist-upgrade-r4.3-vm.sh $opt && rm -f /home/user/QubesIncoming/dom0/qubes-dist-upgrade-r4.3-vm.sh" || exit_code=$?
+                qvm-run -q -u root -p "$vm" "user=\$(qubesdb-read /default-user || echo user); path=/home/\$user/QubesIncoming/dom0/qubes-dist-upgrade-r4.3-vm.sh; bash \"\$path\" $opt && rm -f \"\$path\"" || exit_code=$?
                 qvm-shutdown --wait "$vm"
                 if [ -n "$exit_code" ]; then
                     case "$exit_code" in


### PR DESCRIPTION
This usually means either multiple display manager services installed,
or some other leftover symlink. While not ideal, it isn't the reason to
block further update.