### PR TITLE
Enforce backwards-compatibility after https://github.com/QubesOS/qubes-core-admin-client/pull/452

### DIFF
--- a/scripts/qubes-dist-upgrade-r4.2.sh
+++ b/scripts/qubes-dist-upgrade-r4.2.sh
@@ -340,7 +340,7 @@ if [ "$assumeyes" == "1" ] || confirm "-> Launch upgrade process?"; then
                 for qube in "${extra_keep_running[@]}"; do
                     qvm_shutdown_exclude+=("--exclude=$qube")
                 done
-                qvm-shutdown --wait --all "${qvm_shutdown_exclude[@]}"
+                qvm-shutdown --wait --all --force "${qvm_shutdown_exclude[@]}"
 
                 rpmsave_policy_files_before=( "/etc/qubes-rpc/policy/"*.rpmsave )
                 update_ret=0

--- a/scripts/qubes-dist-upgrade-r4.3.sh
+++ b/scripts/qubes-dist-upgrade-r4.3.sh
@@ -417,7 +417,7 @@ if [ "$assumeyes" == "1" ] || confirm "-> Launch upgrade process?"; then
                 for qube in "${extra_keep_running[@]}"; do
                     qvm_shutdown_exclude+=("--exclude=$qube")
                 done
-                qvm-shutdown --wait --all "${qvm_shutdown_exclude[@]}"
+                qvm-shutdown --wait --all --force "${qvm_shutdown_exclude[@]}"
 
                 rpmsave_policy_files_before=( "/etc/qubes-rpc/policy/"*.rpmsave )
 


### PR DESCRIPTION
Explicit `--force` to preserve behavior following https://github.com/QubesOS/qubes-core-admin-client/pull/452